### PR TITLE
Use standard way of task registration for xBlock tasks

### DIFF
--- a/edx_sga/tasks.py
+++ b/edx_sga/tasks.py
@@ -5,9 +5,9 @@ import logging
 import os
 import tempfile
 
+from celery import task  # pylint: disable=no-name-in-module, import-error
 from django.core.files.storage import default_storage  # lint-amnesty, pylint: disable=import-error
 
-from lms import CELERY_APP  # pylint: disable=no-name-in-module, import-error
 from submissions import api as submissions_api  # lint-amnesty, pylint: disable=import-error
 from student.models import user_by_anonymous_id  # lint-amnesty, pylint: disable=import-error
 from opaque_keys.edx.locator import BlockUsageLocator
@@ -85,7 +85,7 @@ def _compress_student_submissions(zip_file_path, block_id, course_id, locator):
         default_storage.save(zip_file_path, tmp)
 
 
-@CELERY_APP.task
+@task
 def zip_student_submissions(course_id, block_id, locator_unicode, username):
     """
     Task to download all submissions as zip file


### PR DESCRIPTION
#### What are the relevant tickets?
https://youtrack.raccoongang.com/issue/ALUE-794

#### What's this PR do?

For some reason the way all tasks are registered via `lms.CELERY_APP` doesn't work for this xBlock.
Usage of `celery.task` fixes the issue.

PR fixes `KeyError`:

```
# Error traceback:

2019-12-10 05:51:30,603 ERROR 11441 [celery.worker.consumer] consumer.py:429 - Received unregistered task of type u'edx_sga.tasks.zip_student_submissions'.
The message has been ignored and discarded.

Did you remember to import the module containing this task?
Or maybe you are using relative imports?
Please see http://bit.ly/gLye1c for more information.

The full contents of the message body was:
{u'utc': True, u'chord': None, u'args': [u'course-v1:ALU+CSTASRW19+2019_T1', u'block-v1:ALU+CSTASRW19+2019_T1+type@edx_sga+block@c9156e299b314fd08a41e4e27d6b7124', u'block-v1:ALU+CSTASRW19+2019_T1+type@edx_sga+block@c9156e299b314fd08a41e4e27d6b7124', u'volodymyr.vakulenko@raccoongang.com'], u'retries': 0, u'expires': None, u'task': u'edx_sga.tasks.zip_student_submissions', u'callbacks': None, u'errbacks': None, u'timelimit': [None, None], u'taskset': None, u'kwargs': {}, u'eta': None, u'id': u'1efec1bf-663c-41e4-be42-bc5550e18b83'} (518b)
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 465, in on_task_received
    strategies[type_](message, body,
KeyError: u'edx_sga.tasks.zip_student_submissions'
2019-12-10 05:53:58,677 ERROR 11441 [celery.worker.consumer] consumer.py:429 - Received unregistered task of type u'edx_sga.tasks.zip_student_submissions'.
The message has been ignored and discarded.

Did you remember to import the module containing this task?
Or maybe you are using relative imports?
Please see http://bit.ly/gLye1c for more information.

The full contents of the message body was:
{u'utc': True, u'chord': None, u'args': [u'course-v1:ALU+CSTASRW19+2019_T1', u'block-v1:ALU+CSTASRW19+2019_T1+type@edx_sga+block@c9156e299b314fd08a41e4e27d6b7124', u'block-v1:ALU+CSTASRW19+2019_T1+type@edx_sga+block@c9156e299b314fd08a41e4e27d6b7124', u'volodymyr.vakulenko@raccoongang.com'], u'retries': 0, u'expires': None, u'task': u'edx_sga.tasks.zip_student_submissions', u'callbacks': None, u'errbacks': None, u'timelimit': [None, None], u'taskset': None, u'kwargs': {}, u'eta': None, u'id': u'e12ae93c-a9a9-46a3-82ed-4a75daa1a846'} (518b)
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 465, in on_task_received
    strategies[type_](message, body,
KeyError: u'edx_sga.tasks.zip_student_submissions'
```

#### How should this be manually tested?
(Required)

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
